### PR TITLE
Modify the animation of the second truck so that it can hit the player

### DIFF
--- a/Assets/Animation/Truck_Lane2_Hit.anim
+++ b/Assets/Animation/Truck_Lane2_Hit.anim
@@ -19,13 +19,13 @@ AnimationClip:
       m_Curve:
       - serializedVersion: 2
         time: 0
-        value: {x: 2.03, y: -1.81, z: -34.3}
+        value: {x: 0.274, y: -1.81, z: -34.3}
         inSlope: {x: 0, y: 0, z: 0}
         outSlope: {x: 0, y: 0, z: 0}
         tangentMode: 0
       - serializedVersion: 2
         time: 2
-        value: {x: 2.03, y: -1.81, z: 0.45}
+        value: {x: 0.274, y: -1.81, z: 0.45}
         inSlope: {x: 0, y: 0, z: 0}
         outSlope: {x: 0, y: 0, z: 0}
         tangentMode: 0
@@ -77,13 +77,13 @@ AnimationClip:
       m_Curve:
       - serializedVersion: 2
         time: 0
-        value: 2.03
+        value: 0.274
         inSlope: 0
         outSlope: 0
         tangentMode: 136
       - serializedVersion: 2
         time: 2
-        value: 2.03
+        value: 0.274
         inSlope: 0
         outSlope: 0
         tangentMode: 136


### PR DESCRIPTION
# Overview
Modify the animation of the second truck so that it can hit the player

# Reason 
Since the play area for vive and the collider to detect player's position are moved to fil the too large gap between the collider and the first truck,
the animation path of the second truck must be also set nearby the lane for the first truck to hit the player properly.

# Effect 
None