### PR TITLE
Add animation of camera rig for vive when the player is hit by a truck

### DIFF
--- a/Assets/Animation/Truck_Lane2_Hit.anim
+++ b/Assets/Animation/Truck_Lane2_Hit.anim
@@ -19,13 +19,13 @@ AnimationClip:
       m_Curve:
       - serializedVersion: 2
         time: 0
-        value: {x: 2.03, y: -1.81, z: -34.3}
+        value: {x: 0.274, y: -1.81, z: -34.3}
         inSlope: {x: 0, y: 0, z: 0}
         outSlope: {x: 0, y: 0, z: 0}
         tangentMode: 0
       - serializedVersion: 2
         time: 2
-        value: {x: 2.03, y: -1.81, z: 0.45}
+        value: {x: 0.274, y: -1.81, z: 0.45}
         inSlope: {x: 0, y: 0, z: 0}
         outSlope: {x: 0, y: 0, z: 0}
         tangentMode: 0
@@ -77,13 +77,13 @@ AnimationClip:
       m_Curve:
       - serializedVersion: 2
         time: 0
-        value: 2.03
+        value: 0.274
         inSlope: 0
         outSlope: 0
         tangentMode: 136
       - serializedVersion: 2
         time: 2
-        value: 2.03
+        value: 0.274
         inSlope: 0
         outSlope: 0
         tangentMode: 136

--- a/Assets/Animation/Truck_Lane2_Stop.anim
+++ b/Assets/Animation/Truck_Lane2_Stop.anim
@@ -19,13 +19,13 @@ AnimationClip:
       m_Curve:
       - serializedVersion: 2
         time: 0
-        value: {x: 2.03, y: -1.81, z: -34.3}
+        value: {x: 0.274, y: -1.81, z: -34.3}
         inSlope: {x: 0, y: 0, z: 0}
         outSlope: {x: 0, y: 0, z: 0}
         tangentMode: 0
       - serializedVersion: 2
         time: 2
-        value: {x: 2.03, y: -1.81, z: -4.93}
+        value: {x: 0.274, y: -1.81, z: -4.93}
         inSlope: {x: 0, y: 0, z: 0}
         outSlope: {x: 0, y: 0, z: 0}
         tangentMode: 0
@@ -77,13 +77,13 @@ AnimationClip:
       m_Curve:
       - serializedVersion: 2
         time: 0
-        value: 2.03
+        value: 0.274
         inSlope: 0
         outSlope: 0
         tangentMode: 136
       - serializedVersion: 2
         time: 2
-        value: 2.03
+        value: 0.274
         inSlope: 0
         outSlope: 0
         tangentMode: 136

--- a/Assets/Scenes/Guiding.unity
+++ b/Assets/Scenes/Guiding.unity
@@ -354,7 +354,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   hasFinished: 0
   isInMainRoute: 1
-  truckActions: {fileID: 600509426}
 --- !u!114 &118747776
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -381,7 +380,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   hasFinished: 0
   isInMainRoute: 1
-  truckAction: {fileID: 600509426}
   truckFrontGuide: {fileID: 648884658}
 --- !u!114 &118747778
 MonoBehaviour:
@@ -396,7 +394,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   hasFinished: 0
   isInMainRoute: 1
-  truckCheckPeriod: 3
   truck: {fileID: 600509423}
 --- !u!114 &118747779
 MonoBehaviour:
@@ -998,6 +995,136 @@ CapsuleCollider:
   m_Height: 2
   m_Direction: 1
   m_Center: {x: 0, y: -0.78, z: 0}
+--- !u!43 &256427994
+Mesh:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_Name: 
+  serializedVersion: 8
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 24
+    topology: 0
+    baseVertex: 0
+    firstVertex: 0
+    vertexCount: 8
+    localAABB:
+      m_Center: {x: 0, y: 0.01, z: 0}
+      m_Extent: {x: 1.65, y: 0, z: 1.275}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 1
+  m_KeepIndices: 1
+  m_IndexFormat: 0
+  m_IndexBuffer: 000004000100010004000500010005000200020005000600020006000300030006000700030007000000000007000400
+  m_Skin: []
+  m_VertexData:
+    m_CurrentChannels: 13
+    m_VertexCount: 8
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 12
+      format: 0
+      dimension: 4
+    - stream: 0
+      offset: 28
+      format: 0
+      dimension: 2
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 288
+    _typelessdata: 0000c03f0ad7233c000090bf000000000000803f0000803f0000803f00000000000000000000c0bf0ad7233c000090bf000000000000803f0000803f0000803f0000803f000000000000c0bf0ad7233c0000903f000000000000803f0000803f0000803f00000000000000000000c03f0ad7233c0000903f000000000000803f0000803f0000803f0000803f000000003333d33f0ad7233c3333a3bf000000000000803f0000803f00000000000000000000803f3333d3bf0ad7233c3333a3bf000000000000803f0000803f000000000000803f0000803f3333d3bf0ad7233c3333a33f000000000000803f0000803f00000000000000000000803f3333d33f0ad7233c3333a33f000000000000803f0000803f000000000000803f0000803f
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: 0, y: 0.01, z: 0}
+    m_Extent: {x: 1.65, y: 0, z: 1.275}
+  m_MeshUsageFlags: 0
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshOptimized: 0
 --- !u!1001 &308330622
 Prefab:
   m_ObjectHideFlags: 0
@@ -1049,7 +1176,7 @@ Transform:
   m_PrefabParentObject: {fileID: 4005964916532458, guid: 8f846cc941c54124e87908a5de790f64,
     type: 2}
   m_PrefabInternal: {fileID: 308330622}
---- !u!21 &419782098
+--- !u!21 &435916962
 Material:
   serializedVersion: 6
   m_ObjectHideFlags: 0
@@ -1463,7 +1590,7 @@ Prefab:
     m_Modifications:
     - target: {fileID: 4479673058341538, guid: 3c4349c2d9c94e6489c12012b90bb4f3, type: 2}
       propertyPath: m_LocalPosition.x
-      value: 2.03
+      value: 0.274
       objectReference: {fileID: 0}
     - target: {fileID: 4479673058341538, guid: 3c4349c2d9c94e6489c12012b90bb4f3, type: 2}
       propertyPath: m_LocalPosition.y
@@ -2092,7 +2219,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   index: -1
   modelOverride: 
-  shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 3}
   verbose: 0
   createComponents: 1
   updateDynamically: 1
@@ -2139,7 +2266,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   index: -1
   modelOverride: 
-  shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 3}
   verbose: 0
   createComponents: 1
   updateDynamically: 1
@@ -3386,136 +3513,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isInside: 0
---- !u!43 &1732412748
-Mesh:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_Name: 
-  serializedVersion: 8
-  m_SubMeshes:
-  - serializedVersion: 2
-    firstByte: 0
-    indexCount: 24
-    topology: 0
-    baseVertex: 0
-    firstVertex: 0
-    vertexCount: 8
-    localAABB:
-      m_Center: {x: 0, y: 0.01, z: 0}
-      m_Extent: {x: 1.65, y: 0, z: 1.275}
-  m_Shapes:
-    vertices: []
-    shapes: []
-    channels: []
-    fullWeights: []
-  m_BindPose: []
-  m_BoneNameHashes: 
-  m_RootBoneNameHash: 0
-  m_MeshCompression: 0
-  m_IsReadable: 1
-  m_KeepVertices: 1
-  m_KeepIndices: 1
-  m_IndexFormat: 0
-  m_IndexBuffer: 000004000100010004000500010005000200020005000600020006000300030006000700030007000000000007000400
-  m_Skin: []
-  m_VertexData:
-    m_CurrentChannels: 13
-    m_VertexCount: 8
-    m_Channels:
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 12
-      format: 0
-      dimension: 4
-    - stream: 0
-      offset: 28
-      format: 0
-      dimension: 2
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    m_DataSize: 288
-    _typelessdata: 0000c03f0ad7233c000090bf000000000000803f0000803f0000803f00000000000000000000c0bf0ad7233c000090bf000000000000803f0000803f0000803f0000803f000000000000c0bf0ad7233c0000903f000000000000803f0000803f0000803f00000000000000000000c03f0ad7233c0000903f000000000000803f0000803f0000803f0000803f000000003333d33f0ad7233c3333a3bf000000000000803f0000803f00000000000000000000803f3333d3bf0ad7233c3333a3bf000000000000803f0000803f000000000000803f0000803f3333d3bf0ad7233c3333a33f000000000000803f0000803f00000000000000000000803f3333d33f0ad7233c3333a33f000000000000803f0000803f000000000000803f0000803f
-  m_CompressedMesh:
-    m_Vertices:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UV:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Normals:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Tangents:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Weights:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_NormalSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_TangentSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_FloatColors:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_BoneIndices:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Triangles:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UVInfo: 0
-  m_LocalAABB:
-    m_Center: {x: 0, y: 0.01, z: 0}
-    m_Extent: {x: 1.65, y: 0, z: 1.275}
-  m_MeshUsageFlags: 0
-  m_BakedConvexCollisionMesh: 
-  m_BakedTriangleCollisionMesh: 
-  m_MeshOptimized: 0
 --- !u!1 &1739144893
 GameObject:
   m_ObjectHideFlags: 0
@@ -3769,6 +3766,7 @@ GameObject:
   - component: {fileID: 1780284066}
   - component: {fileID: 1780284065}
   - component: {fileID: 1780284064}
+  - component: {fileID: 1780284068}
   m_Layer: 0
   m_Name: '[CameraRig]'
   m_TagString: Untagged
@@ -3826,7 +3824,7 @@ MeshFilter:
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1780284062}
-  m_Mesh: {fileID: 1732412748}
+  m_Mesh: {fileID: 256427994}
 --- !u!23 &1780284066
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -3842,7 +3840,7 @@ MeshRenderer:
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
   m_Materials:
-  - {fileID: 419782098}
+  - {fileID: 435916962}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -3878,6 +3876,20 @@ MonoBehaviour:
   right: {fileID: 1819869818}
   objects: []
   assignAllBeforeIdentified: 0
+--- !u!114 &1780284068
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1780284062}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0d59693199f165245a5e7a85f217ab0f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  cameraPiv: {fileID: 1956650851}
+  viveCamera: {fileID: 680245772}
+  isActivated: 0
 --- !u!1 &1819869818
 GameObject:
   m_ObjectHideFlags: 0
@@ -4212,7 +4224,6 @@ GameObject:
   serializedVersion: 5
   m_Component:
   - component: {fileID: 1956650852}
-  - component: {fileID: 1956650853}
   m_Layer: 0
   m_Name: CameraPiv
   m_TagString: Untagged
@@ -4235,20 +4246,6 @@ Transform:
   m_Father: {fileID: 1780284063}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1956650853
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1956650851}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0d59693199f165245a5e7a85f217ab0f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  cameraRig: {fileID: 1780284062}
-  viveCamera: {fileID: 680245772}
-  isActivated: 0
 --- !u!1 &2005045954
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/AccidentPhase/SecondTruckActions.cs
+++ b/Assets/Scripts/AccidentPhase/SecondTruckActions.cs
@@ -66,6 +66,31 @@ public class SecondTruckActions : MonoBehaviour {
 		Rigidbody rbd = GetComponent<Rigidbody>();
 		rbd.isKinematic = true;
 		rbd.useGravity = false;
-		
+
+
+		// get contact point with the player
+		Vector3 contactPointWithPlayer = GetContactPointWithPlayer(collision);
+		Vector3 contactDirWithPlayer = GetContactDirWithPlayer(collision);
+
+		// activate CameraPosModification on the Camerarig
+		ActivateCamPosModification(contactPointWithPlayer, contactDirWithPlayer);
+	}
+
+	private void ActivateCamPosModification(Vector3 _contactPoint, Vector3 _motionDir){
+		// activate CameraPosModification on the Camerarig
+		var camPosMod = (CameraPosModification)FindObjectOfType(typeof(CameraPosModification));
+		if(camPosMod == null || camPosMod.isActivated) {return;}
+		if(!camPosMod.isActivated) {
+			camPosMod.SetPointsAndNormal(_contactPoint);
+			camPosMod.isActivated = true;
+		}
+	}
+
+	private Vector3 GetContactPointWithPlayer(Collision _collision){
+		return  _collision.contacts[0].point;
+	}
+
+	private Vector3 GetContactDirWithPlayer(Collision _collision){
+		return _collision.contacts[0].normal;
 	}
 }

--- a/Assets/Scripts/AccidentPhase/SecondTruckHits.cs
+++ b/Assets/Scripts/AccidentPhase/SecondTruckHits.cs
@@ -6,11 +6,14 @@
 public class SecondTruckHits : ContentSubBlock {
 
 	private GameObject playerHead;
-
 	private Rigidbody playerRbd;
+	private CameraPosModification camPosMod;
 
 	private void Start () {
+		camPosMod = (CameraPosModification)FindObjectOfType(typeof(CameraPosModification));
+
 		playerHead = GetComponent<GuidingContentManager>().playerHead;
+
 		// animate camera by physics simulation (without vive)
 		var kinematicControl = playerHead.GetComponent<CharacterController>();
 		if(kinematicControl != null) {
@@ -22,7 +25,13 @@ public class SecondTruckHits : ContentSubBlock {
 	}
 	
 	private void Update () {
-		CheckPlayerVel();
+		//CheckPlayerVel(); // for test without vive
+
+		// for test with vive
+		camPosMod.UpdateCamTransform();
+		if(camPosMod.IsMotionEnd()) {
+			FadeSceneOut();
+		}
 	}
 
 	private void CheckPlayerVel(){

--- a/Assets/Scripts/GuidingPhase/CameraPosModification.cs
+++ b/Assets/Scripts/GuidingPhase/CameraPosModification.cs
@@ -1,12 +1,70 @@
 ﻿using UnityEngine;
-
+using UnityEngine.XR;
+/// <summary>
+/// This class modifies the motion of the camera rig for vive
+/// when the player is hit by a truck
+/// </summary>
 public class CameraPosModification : MonoBehaviour {
 
-    public GameObject cameraRig;
+    public GameObject cameraPiv;
     public GameObject viveCamera;
     public bool isActivated = false;
 
-    public void InterpolateCamPos() {
+	private float step = 0f;
+	private Vector3 contactPoint;
+	private Vector3 endPoint;
 
+	public void SetPointsAndNormal(Vector3 _contactPoint){
+		contactPoint = _contactPoint;
+		InitEndPoint();
+	}
+
+	public void UpdateCamTransform(){
+
+		MoveCameraRig();
+
+	}
+
+	public bool IsMotionEnd(){
+		if(step < 1f) {
+			return false;
+		} else {
+			return true;
+		}
+	}
+
+	private void InitEndPoint(){
+		float heightOfEye = 0.15f;
+		float distAlongZAxis = 3.5f;
+		endPoint = new Vector3(0f, heightOfEye, contactPoint.z + distAlongZAxis);
+	}
+
+	private void MoveCameraRig() {
+		if(!isActivated) {return;}
+		float speed = 2f;
+		step = Mathf.Min(step + Time.deltaTime * speed, 1f);
+
+		transform.position = Vector3.Lerp(contactPoint, endPoint, step);
     }
+
+	private void ModifyDiffPosOfCam(){
+		if(!isActivated) {return;}
+		// modify position of the camera of vive
+		Vector3 trackedLocalCamPos = InputTracking.GetLocalPosition(XRNode.CenterEye);
+
+		cameraPiv.transform.position = transform.TransformPoint(-trackedLocalCamPos);
+	}
+
+	private void ModifyDiffRotOfCam(){
+		if(!isActivated) {return;}
+		// modify rotation of the camera of vive
+		Quaternion trackedLocalCamRot = InputTracking.GetLocalRotation(XRNode.CenterEye);
+
+		cameraPiv.transform.rotation = Quaternion.Inverse(trackedLocalCamRot);
+	}
+
+	private void Update(){
+		ModifyDiffPosOfCam();
+
+	}
 }


### PR DESCRIPTION
# Overview 
Add animation of camera rig for vive when the player is hit by a truck

# Reason 
The method of animation when the player is hit by a truck must be altered while keep using tracking system,
instead of rigid body simulation, which was used for test without vive.

# Effect 
Not found currently