### PR TITLE
Modify interaction between the second truck and the player

### DIFF
--- a/Assets/Animation/Man_Truck02.controller
+++ b/Assets/Animation/Man_Truck02.controller
@@ -112,7 +112,7 @@ AnimatorStateMachine:
     m_Position: {x: 420.375, y: 83, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 1102868873562667564}
-    m_Position: {x: 744, y: 0, z: 0}
+    m_Position: {x: 420, y: -72, z: 0}
   m_ChildStateMachines: []
   m_AnyStateTransitions: []
   m_EntryTransitions: []

--- a/Assets/Scenes/Guiding.unity
+++ b/Assets/Scenes/Guiding.unity
@@ -113,35 +113,6 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
---- !u!1 &29929740
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 29929741}
-  m_Layer: 0
-  m_Name: rig
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &29929741
-Transform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 29929740}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -6.265604, y: -5.641032, z: 8.27}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 1346294274}
-  m_Father: {fileID: 0}
-  m_RootOrder: 18
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &77639745
 GameObject:
   m_ObjectHideFlags: 0
@@ -306,6 +277,7 @@ MonoBehaviour:
   secondTruckStops2: {fileID: 118747775}
   playerHead: {fileID: 680245772}
   playerRbdDummy: {fileID: 964738996}
+  secondTruck: {fileID: 600509422}
   typeOfEnding: {fileID: 1909088214}
 --- !u!114 &118747773
 MonoBehaviour:
@@ -995,136 +967,6 @@ CapsuleCollider:
   m_Height: 2
   m_Direction: 1
   m_Center: {x: 0, y: -0.78, z: 0}
---- !u!43 &256427994
-Mesh:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_Name: 
-  serializedVersion: 8
-  m_SubMeshes:
-  - serializedVersion: 2
-    firstByte: 0
-    indexCount: 24
-    topology: 0
-    baseVertex: 0
-    firstVertex: 0
-    vertexCount: 8
-    localAABB:
-      m_Center: {x: 0, y: 0.01, z: 0}
-      m_Extent: {x: 1.65, y: 0, z: 1.275}
-  m_Shapes:
-    vertices: []
-    shapes: []
-    channels: []
-    fullWeights: []
-  m_BindPose: []
-  m_BoneNameHashes: 
-  m_RootBoneNameHash: 0
-  m_MeshCompression: 0
-  m_IsReadable: 1
-  m_KeepVertices: 1
-  m_KeepIndices: 1
-  m_IndexFormat: 0
-  m_IndexBuffer: 000004000100010004000500010005000200020005000600020006000300030006000700030007000000000007000400
-  m_Skin: []
-  m_VertexData:
-    m_CurrentChannels: 13
-    m_VertexCount: 8
-    m_Channels:
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 12
-      format: 0
-      dimension: 4
-    - stream: 0
-      offset: 28
-      format: 0
-      dimension: 2
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    m_DataSize: 288
-    _typelessdata: 0000c03f0ad7233c000090bf000000000000803f0000803f0000803f00000000000000000000c0bf0ad7233c000090bf000000000000803f0000803f0000803f0000803f000000000000c0bf0ad7233c0000903f000000000000803f0000803f0000803f00000000000000000000c03f0ad7233c0000903f000000000000803f0000803f0000803f0000803f000000003333d33f0ad7233c3333a3bf000000000000803f0000803f00000000000000000000803f3333d3bf0ad7233c3333a3bf000000000000803f0000803f000000000000803f0000803f3333d3bf0ad7233c3333a33f000000000000803f0000803f00000000000000000000803f3333d33f0ad7233c3333a33f000000000000803f0000803f000000000000803f0000803f
-  m_CompressedMesh:
-    m_Vertices:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UV:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Normals:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Tangents:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Weights:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_NormalSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_TangentSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_FloatColors:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_BoneIndices:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Triangles:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UVInfo: 0
-  m_LocalAABB:
-    m_Center: {x: 0, y: 0.01, z: 0}
-    m_Extent: {x: 1.65, y: 0, z: 1.275}
-  m_MeshUsageFlags: 0
-  m_BakedConvexCollisionMesh: 
-  m_BakedTriangleCollisionMesh: 
-  m_MeshOptimized: 0
 --- !u!1001 &308330622
 Prefab:
   m_ObjectHideFlags: 0
@@ -1176,39 +1018,6 @@ Transform:
   m_PrefabParentObject: {fileID: 4005964916532458, guid: 8f846cc941c54124e87908a5de790f64,
     type: 2}
   m_PrefabInternal: {fileID: 308330622}
---- !u!21 &435916962
-Material:
-  serializedVersion: 6
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_Name: Sprites/Default
-  m_Shader: {fileID: 10753, guid: 0000000000000000f000000000000000, type: 0}
-  m_ShaderKeywords: 
-  m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
-  m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  disabledShaderPasses: []
-  m_SavedProperties:
-    serializedVersion: 3
-    m_TexEnvs:
-    - _AlphaTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _MainTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Floats:
-    - PixelSnap: 0
-    - _EnableExternalAlpha: 0
-    m_Colors:
-    - _Color: {r: 1, g: 1, b: 1, a: 1}
-    - _Flip: {r: 1, g: 1, b: 1, a: 1}
-    - _RendererColor: {r: 1, g: 1, b: 1, a: 1}
 --- !u!1 &455321382
 GameObject:
   m_ObjectHideFlags: 0
@@ -1627,22 +1436,27 @@ Prefab:
     - target: {fileID: 65579056166628550, guid: 3c4349c2d9c94e6489c12012b90bb4f3,
         type: 2}
       propertyPath: m_Size.z
-      value: 2.717548
+      value: 2.4580007
       objectReference: {fileID: 0}
     - target: {fileID: 65579056166628550, guid: 3c4349c2d9c94e6489c12012b90bb4f3,
         type: 2}
       propertyPath: m_Center.z
-      value: 0.6779692
+      value: 0.5481956
       objectReference: {fileID: 0}
     - target: {fileID: 65579056166628550, guid: 3c4349c2d9c94e6489c12012b90bb4f3,
         type: 2}
       propertyPath: m_Size.x
-      value: 3.2799997
+      value: 2.4
       objectReference: {fileID: 0}
     - target: {fileID: 65579056166628550, guid: 3c4349c2d9c94e6489c12012b90bb4f3,
         type: 2}
       propertyPath: m_Center.x
       value: 0.61920404
+      objectReference: {fileID: 0}
+    - target: {fileID: 65579056166628550, guid: 3c4349c2d9c94e6489c12012b90bb4f3,
+        type: 2}
+      propertyPath: m_IsTrigger
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 3c4349c2d9c94e6489c12012b90bb4f3, type: 2}
@@ -1674,21 +1488,6 @@ Animator:
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
---- !u!54 &600509425
-Rigidbody:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 600509422}
-  serializedVersion: 2
-  m_Mass: 1000
-  m_Drag: 0.5
-  m_AngularDrag: 0.05
-  m_UseGravity: 1
-  m_IsKinematic: 0
-  m_Interpolate: 0
-  m_Constraints: 0
-  m_CollisionDetection: 0
 --- !u!114 &600509426
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1890,7 +1689,6 @@ GameObject:
   m_Component:
   - component: {fileID: 648884658}
   - component: {fileID: 648884661}
-  - component: {fileID: 648884660}
   - component: {fileID: 648884659}
   m_Layer: 0
   m_Name: SecondTruckFrontGuide
@@ -1946,18 +1744,6 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
---- !u!135 &648884660
-SphereCollider:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 648884657}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Radius: 0.5
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!33 &648884661
 MeshFilter:
   m_ObjectHideFlags: 0
@@ -2270,6 +2056,39 @@ MonoBehaviour:
   verbose: 0
   createComponents: 1
   updateDynamically: 1
+--- !u!21 &876713373
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_Name: Sprites/Default
+  m_Shader: {fileID: 10753, guid: 0000000000000000f000000000000000, type: 0}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _AlphaTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - PixelSnap: 0
+    - _EnableExternalAlpha: 0
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _Flip: {r: 1, g: 1, b: 1, a: 1}
+    - _RendererColor: {r: 1, g: 1, b: 1, a: 1}
 --- !u!1 &887572729
 GameObject:
   m_ObjectHideFlags: 0
@@ -2898,34 +2717,6 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1199740353}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!1 &1300405822
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 1300405823}
-  m_Layer: 0
-  m_Name: camera
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1300405823
-Transform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1300405822}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 1, y: 1.7, z: 1}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1346294274}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1332332759
 Prefab:
   m_ObjectHideFlags: 0
@@ -2985,35 +2776,6 @@ Transform:
   m_PrefabParentObject: {fileID: 4005964916532458, guid: 8f846cc941c54124e87908a5de790f64,
     type: 2}
   m_PrefabInternal: {fileID: 1332332759}
---- !u!1 &1346294273
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 1346294274}
-  m_Layer: 0
-  m_Name: camerapiv
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1346294274
-Transform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1346294273}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -1, y: -1.7, z: -1}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 1300405823}
-  m_Father: {fileID: 29929741}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1348114627
 GameObject:
   m_ObjectHideFlags: 0
@@ -3108,7 +2870,7 @@ GameObject:
   - component: {fileID: 1378360132}
   - component: {fileID: 1378360131}
   - component: {fileID: 1378360130}
-  m_Layer: 0
+  m_Layer: 2
   m_Name: PlayerTargetZone01
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3469,7 +3231,7 @@ GameObject:
   - component: {fileID: 1651349025}
   - component: {fileID: 1651349024}
   - component: {fileID: 1651349026}
-  m_Layer: 0
+  m_Layer: 2
   m_Name: PlayerTargetZone02
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3513,6 +3275,136 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isInside: 0
+--- !u!43 &1712109610
+Mesh:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_Name: 
+  serializedVersion: 8
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 24
+    topology: 0
+    baseVertex: 0
+    firstVertex: 0
+    vertexCount: 8
+    localAABB:
+      m_Center: {x: 0, y: 0.01, z: 0}
+      m_Extent: {x: 1.65, y: 0, z: 1.275}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 1
+  m_KeepIndices: 1
+  m_IndexFormat: 0
+  m_IndexBuffer: 000004000100010004000500010005000200020005000600020006000300030006000700030007000000000007000400
+  m_Skin: []
+  m_VertexData:
+    m_CurrentChannels: 13
+    m_VertexCount: 8
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 12
+      format: 0
+      dimension: 4
+    - stream: 0
+      offset: 28
+      format: 0
+      dimension: 2
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 288
+    _typelessdata: 0000c03f0ad7233c000090bf000000000000803f0000803f0000803f00000000000000000000c0bf0ad7233c000090bf000000000000803f0000803f0000803f0000803f000000000000c0bf0ad7233c0000903f000000000000803f0000803f0000803f00000000000000000000c03f0ad7233c0000903f000000000000803f0000803f0000803f0000803f000000003333d33f0ad7233c3333a3bf000000000000803f0000803f00000000000000000000803f3333d3bf0ad7233c3333a3bf000000000000803f0000803f000000000000803f0000803f3333d3bf0ad7233c3333a33f000000000000803f0000803f00000000000000000000803f3333d33f0ad7233c3333a33f000000000000803f0000803f000000000000803f0000803f
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: 0, y: 0.01, z: 0}
+    m_Extent: {x: 1.65, y: 0, z: 1.275}
+  m_MeshUsageFlags: 0
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshOptimized: 0
 --- !u!1 &1739144893
 GameObject:
   m_ObjectHideFlags: 0
@@ -3824,7 +3716,7 @@ MeshFilter:
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1780284062}
-  m_Mesh: {fileID: 256427994}
+  m_Mesh: {fileID: 1712109610}
 --- !u!23 &1780284066
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -3840,7 +3732,7 @@ MeshRenderer:
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
   m_Materials:
-  - {fileID: 435916962}
+  - {fileID: 876713373}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -4339,7 +4231,6 @@ GameObject:
   m_Component:
   - component: {fileID: 2008214213}
   - component: {fileID: 2008214217}
-  - component: {fileID: 2008214216}
   - component: {fileID: 2008214215}
   - component: {fileID: 2008214214}
   m_Layer: 0
@@ -4476,18 +4367,6 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
---- !u!135 &2008214216
-SphereCollider:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 2008214212}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Radius: 0.5
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!33 &2008214217
 MeshFilter:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/AccidentPhase/SecondTruckComing.cs
+++ b/Assets/Scripts/AccidentPhase/SecondTruckComing.cs
@@ -8,15 +8,19 @@ public class SecondTruckComing : ContentSubBlock {
 
 
 	public Transform truckFrontGuide;
+	private GameObject truck;
 	private SecondTruckActions truckAction;
 	private Transform playerHead;
 
 	private void Start(){
-		playerHead = GetComponent<GuidingContentManager>().playerHead.transform;
+		GuidingContentManager contentManager = GetComponent<GuidingContentManager>();
+		playerHead = contentManager.playerHead.transform;
+		truck = contentManager.secondTruck;
 		truckAction = (SecondTruckActions)GameObject.FindObjectOfType(typeof(SecondTruckActions));
 	}
 
 	private void Update () {
+		CheckTruckRecognition();
 		CheckPlayerTruckContact();
 	}
 
@@ -30,8 +34,34 @@ public class SecondTruckComing : ContentSubBlock {
 		} else if (!truckAction.isContacting && truckHasPassed){
 			// move on "SecondTruckStops"
 			Debug.Log("SecondTruckComing has finished (SecondTruckStops)");
+			truckAction.ActivateActionsAfterHit();
 			isInMainRoute = false;
 			hasFinished = true;
 		}
+	}
+
+	private void CheckTruckRecognition(){
+		bool willTruckHit = true;
+
+		if(PlayerSawTruck()) {
+			// move on instruction phase
+			Debug.Log("truck 02 animation has played");
+			willTruckHit = false;
+			truckAction.ActivateActionsAfterHit();
+			isInMainRoute = false;
+			hasFinished = true;
+		}
+	}
+
+	private bool PlayerSawTruck(){
+		
+		float viewDirThreshold = 0.5f;
+		Vector3 truckDir = Vector3.Normalize(truck.transform.position
+			- new Vector3(playerHead.position.x, truck.transform.position.y, playerHead.position.z));
+		Vector3 viewAngle = playerHead.transform.forward.normalized;
+
+		float viewAngleDotTruckDir = Vector3.Dot(viewAngle, truckDir);
+
+		return viewAngleDotTruckDir > viewDirThreshold;
 	}
 }

--- a/Assets/Scripts/AccidentPhase/SecondTruckFound.cs
+++ b/Assets/Scripts/AccidentPhase/SecondTruckFound.cs
@@ -5,14 +5,16 @@
 /// </summary>
 public class SecondTruckFound : ContentSubBlock {
 
-	public Transform truck;
+	private Transform truck;
 	private float truckCheckPeriod = 3f;
 	private Transform playerHead;
 	private float truckCheckDeadline;
 
 	private void Start(){
+		GuidingContentManager contentManager = GetComponent<GuidingContentManager>();
+		truck = contentManager.secondTruck.transform;
 		truckCheckDeadline = Time.time + truckCheckPeriod;
-		playerHead = GetComponent<GuidingContentManager>().playerHead.transform;
+		playerHead = contentManager.playerHead.transform;
 	}
 
 	private void StartTruckActions(){

--- a/Assets/Scripts/AccidentPhase/SecondTruckStops1.cs
+++ b/Assets/Scripts/AccidentPhase/SecondTruckStops1.cs
@@ -8,11 +8,10 @@ public class SecondTruckStops1 : ContentSubBlock {
 	public SecondTruckActions truckActions;
 
 	private void Update () {
-		ActivateTruckActions();
+		EndStoryBlock();
 	}
 
-	private void ActivateTruckActions(){
-		// when the audio clip on the "truckActions" finish,
+	private void EndStoryBlock(){
 		// end this block of the story
 		if (!truckActions.truckSoundAfterHit.isPlaying){
 			hasFinished = true;

--- a/Assets/Scripts/GuidingPhase/GuidingContentManager.cs
+++ b/Assets/Scripts/GuidingPhase/GuidingContentManager.cs
@@ -23,6 +23,7 @@ public class GuidingContentManager : ContentManager {
 
 	public GameObject playerHead;
 	public GameObject playerRbdDummy;
+	public GameObject secondTruck;
 
 	public Text typeOfEnding;
 
@@ -40,7 +41,7 @@ public class GuidingContentManager : ContentManager {
 		truckComing.InitUI();
 
 		// Initialize player's rigid body status
-		InitPlayerRbd();
+		//InitPlayerRbd();
 
 		// Initialize "type of ending" UI panel (for prototyping)
 		InitTypeOfEndDisplay();


### PR DESCRIPTION
# Overview 
Modify interaction between the second truck and the player

# Reason
Collision detection between the second truck and the player must be altered by trigger collider and raycasting, to avoid effect of physics simulation on the second truck animation

# Effect 
None

# Issue
The transition of two animation states for the second truck, which are for hitting the player and stopping in front of the player, does not work properly.
It requires a kind of cross fading of animators in runtime.